### PR TITLE
fix(types): drive typecheck to zero and enforce it in CI [WTEL-9942]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"prepare": "husky || true",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit:ci": "vitest run --coverage",
-		"typecheck:ci": "true"
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.json",
+		"typecheck:ci": "npm run typecheck"
 	},
 	"type": "module",
 	"dependencies": {

--- a/src/app/assets/icons/sprite/index.ts
+++ b/src/app/assets/icons/sprite/index.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error він там є!
 import { fillIconsRepository } from '@webitel/ui-sdk';
 import deskTrack from './desk-track.svg?raw';
 import ratedCalls from './rated-calls.svg?raw';

--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -3,7 +3,11 @@ import {
 	WtApplication,
 	WtObject,
 } from '@webitel/ui-sdk/enums';
-import { createRouter, createWebHistory } from 'vue-router';
+import {
+	createRouter,
+	createWebHistory,
+	type RouteRecordRaw,
+} from 'vue-router';
 import Calls from '../../modules/agents/modules/agent-card/modules/agent-calls/components/agent-calls-tab.vue';
 import General from '../../modules/agents/modules/agent-card/modules/agent-general/components/agent-general-tab.vue';
 import Pdfs from '../../modules/agents/modules/agent-card/modules/agent-pdfs/components/agent-pdfs-tab.vue';
@@ -144,16 +148,16 @@ export const initRouter = async ({
 	router = createRouter({
 		history: createWebHistory(import.meta.env.BASE_URL),
 
-		scrollBehavior(to, from, savedPosition) {
+		scrollBehavior(_to, _from, _savedPosition) {
 			return {
 				left: 0,
 				top: 0,
 			};
 		},
-		routes,
+		routes: routes as RouteRecordRaw[],
 	});
 
-	router.beforeEach((to, from, next) => {
+	router.beforeEach((to, _from, next) => {
 		if (!localStorage.getItem('access-token') && !to.query.accessToken) {
 			// @author @Lear24
 			// remove flag about shown notifications from localStorage

--- a/src/modules/agents/modules/agent-card/modules/agent-screen-recordings/components/agent-screen-recordings-tab.vue
+++ b/src/modules/agents/modules/agent-card/modules/agent-screen-recordings/components/agent-screen-recordings-tab.vue
@@ -126,24 +126,20 @@ import { getEndOfDay, getStartOfDay } from '@webitel/ui-sdk/scripts';
 import DeleteConfirmationPopup from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/components/delete-confirmation-popup.vue';
 import { useDeleteConfirmationPopup } from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/composables/useDeleteConfirmationPopup';
 import { useTableEmpty } from '@webitel/ui-sdk/src/modules/TableComponentModule/composables/useTableEmpty';
-import getNamespacedState from '@webitel/ui-sdk/store/helpers/getNamespacedState.js';
 import { formatDate } from '@webitel/ui-sdk/utils';
 import { storeToRefs } from 'pinia';
 import { computed, defineEmits, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
-import { useStore } from 'vuex';
 
 import { useTableAutoRefresh } from '../../../../../../../app/composables/useTableAutoRefresh';
 import { useScreenRecordingsDataListStore } from '../store/screen-recordings';
 
 const { t } = useI18n();
 
-const props = defineProps({
+defineProps({
 	namespace: String,
 });
-
-const store = useStore();
 
 const route = useRoute();
 const agentId = route.params.id;
@@ -151,10 +147,6 @@ const agentId = route.params.id;
 const emit = defineEmits([
 	'toggle-filter',
 ]);
-
-const agent = computed(() => {
-	return getNamespacedState(store.state, props.namespace).agent;
-});
 
 const currentVideo = ref(null);
 const isVideoOpen = ref(false);
@@ -251,7 +243,11 @@ const {
 	isLoading,
 });
 
-const handleDelete = async (items: []) => {
+const handleDelete = async (
+	items: {
+		id: string;
+	}[],
+) => {
 	const deleteEl = (el) => {
 		return FileServicesAPI.deleteScreenRecordingsByAgent({
 			id: el.id,

--- a/src/modules/agents/modules/agent-card/modules/agent-screenshots/components/agent-screenshots-tab.vue
+++ b/src/modules/agents/modules/agent-card/modules/agent-screenshots/components/agent-screenshots-tab.vue
@@ -248,7 +248,11 @@ const openScreenshot = (id) => {
 	galleriaVisible.value = true;
 };
 
-const handleDelete = async (items: []) => {
+const handleDelete = async (
+	items: {
+		id: string;
+	}[],
+) => {
 	const deleteEl = (el) => {
 		return FileServicesAPI.deleteScreenRecordingsByAgent({
 			id: el.id,

--- a/src/modules/start-page/stores/navStore.ts
+++ b/src/modules/start-page/stores/navStore.ts
@@ -68,7 +68,11 @@ export const useNavStore = defineStore('nav', () => {
 			const route = router.resolve({
 				path: navItem.route,
 			});
-			const hasAccess = routeAccessGuard(route) === true;
+			// TODO(types): SDK routeAccessGuard is typed as a 3-arg NavigationGuard but only reads `to` and returns a boolean.
+			const hasAccess =
+				(
+					routeAccessGuard as (to: ReturnType<typeof router.resolve>) => boolean
+				)(route) === true;
 			return {
 				...navItem,
 				disabled: !hasAccess,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,48 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["esnext", "dom"],
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowJs": false,
-    "skipLibCheck": true,
-    "listEmittedFiles": true,
-    "plugins": [
-      {
-        "name": "typescript-plugin-css-modules"
-      }
-    ],
-    "moduleResolution": "Bundler",
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "noEmitOnError": false,
-    "strict": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["src/**/*.ts", "docs/pages/**/*.ts"],
-  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowJs": false,
+		"skipLibCheck": true,
+		"listEmittedFiles": true,
+		"plugins": [
+			{
+				"name": "typescript-plugin-css-modules"
+			}
+		],
+		"moduleResolution": "Bundler",
+		"baseUrl": ".",
+		"paths": {
+			"@webitel/ui-sdk/src/*": [
+				"./node_modules/@webitel/ui-sdk/types/*"
+			],
+			"@webitel/ui-datalist/src/*": [
+				"./node_modules/@webitel/ui-datalist/types/*"
+			]
+		},
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"noEmitOnError": false,
+		"strict": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"docs/pages/**/*.ts"
+	],
+	"exclude": [
+		"**/*.spec.ts",
+		"**/*.test.ts"
+	]
 }


### PR DESCRIPTION
## What

Drives `vue-tsc` from **32 errors → 0** and enables a real typecheck gate — `typecheck:ci` was stubbed as `"true"`, so CI never caught type regressions.

Ticket: [WTEL-9942](https://webitel.atlassian.net/browse/WTEL-9942)

## Root causes

- **SDK module resolution (21 errors).** Published `@webitel/ui-sdk` + `@webitel/ui-datalist` ship correct `.d.ts`, but their `exports` maps use extensionless wildcard `types` targets (e.g. `"./src/scripts*": {"types":"./types/scripts*"}`), so `vue-tsc` can't resolve them for any `.js`/`.vue` module deep-imported from a `.ts`/`.vue` file. Symptoms: `TS2307` on `eventBus`/`useTableEmpty`/etc., plus 14 errors from `AgentPdfs/*.vue` being type-checked as raw source instead of via the shipped `.vue.d.ts`.
- **router** — unused guard/scroll params; a route with `redirect`+`component`+`children` can't satisfy vue-router's `RouteRecordRaw` union.
- **navStore** — SDK's `routeAccessGuard` is mis-typed as a 3-arg `NavigationGuard` but only uses `to`.
- **sprite** — stale `@ts-expect-error`.
- **screen-recordings/screenshots tabs** — local `handleDelete(items: [])` (empty tuple) + dead `agent`/`store` code.

## Changes

- **tsconfig** — `paths` redirect `@webitel/ui-sdk|ui-datalist/src/*` → each package's shipped `types/*` (TS-only; Vite has its own resolver). Matches the pattern used in the other apps. Add `src/**/*.vue` to `include`.
- **package.json** — add real `typecheck` script; `typecheck:ci` now runs it.
- **src** — the type-level fixes above. No runtime behavior changed.

## Notes

- No `@ts-ignore` / `as any` / `unknown`-casts. Two documented `as` narrowings only.
- Latent, currently-masked mismatch left as-is: `agent-pdfs/store/pdfs.ts` passes the whole `PdfServicesAPI` as `apiModule` (its `delete(id: string)` is incompatible with datalist's `ApiModule.delete`). Harmless today; fix would be to mirror the sibling stores (`apiModule: { getList: PdfServicesAPI.getList }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-9942]: https://webitel.atlassian.net/browse/WTEL-9942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ