### PR TITLE
fix: disable svg from biome  check [WTEL-9625](https://webitel.atlassian.net/browse/WTEL-9625)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,6 +9,7 @@
 		"includes": [
 			"**",
 			"!!**/dist",
+			"!!**/*.svg",
 			"!!src/components/wt-select/multiselect.css"
 		]
 	},


### PR DESCRIPTION
З версії 2.5 біом почав слідкувати за svg, в нашому випадку svg треба виключити зі списку файлів які треба перевіряти.