### PR TITLE
refactor: remove @aliasedDeps axios alias [WTEL-10132](https://webitel.atlassian.net/browse/WTEL-10132)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@vue/tsconfig": "^0.9.1",
 				"@vuelidate/core": "^2.0.3",
 				"@vuelidate/validators": "^2.0.4",
-				"@webitel/api-services": "^0.1.54",
+				"@webitel/api-services": "^1.0.3",
 				"@webitel/styleguide": "~26.2.19",
 				"@webitel/ui-datalist": "^1.1.56",
 				"@webitel/ui-sdk": "~26.8.13",
@@ -3714,9 +3714,9 @@
 			}
 		},
 		"node_modules/@webitel/api-services": {
-			"version": "0.1.59",
-			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-0.1.59.tgz",
-			"integrity": "sha512-FkK+CbXHF63iuyYjRPAXPCw/ZR+qu8rY7laBhlZ5r4HnBBgD0jD8BeKgxaTiq5dcEADFlezivGqwe21RYH59Hw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-1.0.3.tgz",
+			"integrity": "sha512-hHCmbeemldQSKDNZc7L96+WvJuds97XpPPYPZu7BwVKPmzoliYB1QVP4HRwfcLS4lmk4/QlvFrYDOeC6Uv8e5g==",
 			"dependencies": {
 				"@faker-js/faker": "^9.7.0",
 				"lodash-es": "^4.17.21",
@@ -3728,6 +3728,8 @@
 				"npm": "11"
 			},
 			"peerDependencies": {
+				"axios": "^1.15.2",
+				"date-fns": "^4.1.0",
 				"deep-copy": "^1.4.2",
 				"deep-equal": "^2.2.3",
 				"deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@vue/tsconfig": "^0.9.1",
 		"@vuelidate/core": "^2.0.3",
 		"@vuelidate/validators": "^2.0.4",
-		"@webitel/api-services": "^0.1.54",
+		"@webitel/api-services": "^1.0.3",
 		"@webitel/styleguide": "~26.2.19",
 		"@webitel/ui-datalist": "^1.1.56",
 		"@webitel/ui-sdk": "~26.8.13",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import './app/assets/icons/sprite';
 import './app/css/main.scss';
 
+import { setDefaultAxiosInstance } from '@webitel/api-services/api/axios';
 import { createPinia } from 'pinia';
 import { createApp } from 'vue';
+import instance from './app/api/instance';
 import { createUserAccessControl } from './app/composables/useUserAccessControl';
 import i18n from './app/locale/i18n';
 import {
@@ -39,6 +41,9 @@ const fetchConfig = async () => {
 	const response = await fetch(`${import.meta.env.BASE_URL}/config.json`);
 	return response.json();
 };
+
+// generated api-services clients call through this app's instance
+setDefaultAxiosInstance(instance);
 
 const pinia = createPinia();
 

--- a/src/modules/agents/modules/agent-card/modules/agent-calls/api/__tests__/agent-calls.spec.js
+++ b/src/modules/agents/modules/agent-card/modules/agent-calls/api/__tests__/agent-calls.spec.js
@@ -29,7 +29,7 @@ const { searchMock, items } = vi.hoisted(() => {
 	};
 });
 
-vi.mock('@webitel/api-services/gen', () => ({
+vi.mock('@webitel/api-services/gen-wire', () => ({
 	getCallService: () => ({
 		searchHistoryCallPost: searchMock,
 	}),

--- a/src/modules/agents/modules/agent-card/modules/agent-calls/api/agent-calls.js
+++ b/src/modules/agents/modules/agent-card/modules/agent-calls/api/agent-calls.js
@@ -1,4 +1,4 @@
-import { getCallService } from '@webitel/api-services/gen';
+import { getCallService } from '@webitel/api-services/gen-wire';
 import { FormatDateMode } from '@webitel/ui-sdk/enums';
 import {
 	getDefaultGetListResponse,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,10 +39,6 @@ export default ({ mode }) => {
 				'@': resolve(__dirname, 'src'),
 				'lodash/fp': 'lodash-es',
 				lodash: 'lodash-es',
-				'@aliasedDeps/api-services/axios': resolve(
-					__dirname,
-					'src/app/api/instance',
-				),
 			},
 		},
 		plugins: [


### PR DESCRIPTION
> **Draft — blocked on the `@webitel/api-services` release** carrying [webitel-ui-sdk#1658](https://github.com/webitel/webitel-ui-sdk/pull/1658). CI stays red until this app's dep is bumped.

## Why

Generated api-services clients used to import their default axios instance from `@aliasedDeps/api-services/axios` — a specifier that does not resolve on its own, so every consumer had to declare a Vite alias for it or the build broke. #1658 replaced it with an internal module that falls back to `getDefaultInstance()` and can be swapped via `setDefaultAxiosInstance()`.

## Changes

- `vite.config.ts` — alias entry deleted.
- `src/main.ts` — registers this app's instance at bootstrap:

  ```ts
  setDefaultAxiosInstance(instance);
  ```

  `src/app/api/instance.js` stays untouched — it is this app's own instance, imported by 25 modules, and not a copy of the package default. Registering it means generated services call through the same one.
- `.../agent-calls/api/agent-calls.js` — `getCallService` now comes from `/gen-wire`; api-services generates in two passes and services live in the wire pass. Its spec's `vi.mock` target is retargeted to match.

## Verification

- `npm run build` — **green**, against a local workspace checkout of api-services carrying the change.
- `npm run test:unit` — 40 passed / 6 failed files (86 / 21 tests). Byte-identical to unmodified `main`, so this change adds no failures. The one spec touched here (`agent-calls.spec.js`) passes on its own: 1/1.
- `biome check ./src` clean.

Runtime behaviour in a browser not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the latest API services.
  * Ensured generated API requests use the application’s configured connection settings.
  * Updated agent call handling to work consistently with the current API service interface.

* **Chores**
  * Refined application configuration to support the updated service integration while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->